### PR TITLE
Generalized the presentation of crossfilter bar charts.

### DIFF
--- a/webworm/static/webworm/crossfilter_helpers.js
+++ b/webworm/static/webworm/crossfilter_helpers.js
@@ -176,13 +176,15 @@ function createXfilterParams(paramObject, rawInputData) {
     paramObject['datasetview_chart_index'] = paramObject['num_display_fields'] - 1;
     for (var i=0; i< numFeatures; i++) {
 	let fieldName = crossfilterHeader[i];
+	// *CWL* Keeping this around in case I still need to use it.
+	//	let fieldRange = getExtremes(rawInputData, fieldName);
 	paramObject['data_fields'][fieldName] = { 
 	    "data_type": "numeric",
 	    "display_name": fieldName,
 	    "suffix": "",
 	    "scale": "linear",
 	    "bucket_width": 1,
-	    "rangeRound":[0,200],
+	    "rangeRound":[0,$('#crossfilterPane').width()/3.5],
 	    "stratify": 1
 	};
 	paramObject['charts'].push(fieldName);

--- a/webworm/static/webworm/worm_filter.css
+++ b/webworm/static/webworm/worm_filter.css
@@ -35,6 +35,7 @@ h2 {
 }
 .chart {
     display: inline-block;
+    width: 33%;
     height: 151px;
     margin-bottom: 20px;
 }
@@ -70,17 +71,8 @@ h2 {
     fill: #eee;
     stroke: #666;
 }
-#chart1 {
-    width: 260px;
-}
-#chart2 {
-    width: 230px;
-}
-#chart3 {
-    width: 420px;
-}
-#chart4 {
-    width: 920px;
+#chart0 {
+    width: 100%;
 }
 #datasetview {
     padding: 2px;


### PR DESCRIPTION
It turned out the original code had hard-coded width
specifications in the CSS file. This has now been replaced
by 33% width for all other than the range of dates which
stretches out 100%.
Also all rangeRound values from dynamic fields are now a
factor of the panel's width. This has resulted in bar charts
that appear to work well with all 10 core features, and is
expected to work reasonably well in general. Until we
encounter a new case (e.g. if the values are in the extreme
and the labels get too squished along the axis) which is
degenerate, I am comfortable declaring this "general enough"