### PR TITLE
Table Output for Results List

### DIFF
--- a/webworm/static/webworm/crossfilter_helpers.js
+++ b/webworm/static/webworm/crossfilter_helpers.js
@@ -632,3 +632,31 @@ function resultsList(grouping_dimension) {
             .text(d => valueFormatted(d, cur_field));
     }
 }
+
+function resultsTable(grouping_dimension) {
+    // Re-run the results list, by erasing it and creating it again
+
+    let div = d3.select("#results-list");
+    // Clear the existing results
+    div.selectAll("table").remove();
+
+    // Create a table with one row for each record in the crossfilter construct
+    let table = div.append("table").attr("class", "display").attr("class","nowrap")
+	.attr("border",1);
+    let tableHead = table.append("thead").append("tr");
+    let tableBody = table.append("tbody");
+    let trs = tableBody.selectAll("tr").data(grouping_dimension.top(XFILTER_PARAMS.max_results))
+        .enter().append("tr");
+    /*
+    let trs = tableBody.selectAll("tr").data(grouping_dimension.top(Infinity))
+        .enter().append("tr");
+    */
+
+    // Loop over all columns we are supposed to display in the results
+    for(let len = XFILTER_PARAMS.results_display.length, i=0; i<len; i++) {
+        let cur_field = XFILTER_PARAMS.results_display[i];
+
+        tableHead.append("td").html(XFILTER_PARAMS.data_fields[cur_field].display_name);
+        trs.append("td").html(d => valueFormatted(d, cur_field));
+    }
+}

--- a/webworm/static/webworm/crossfilter_main.js
+++ b/webworm/static/webworm/crossfilter_main.js
@@ -107,7 +107,8 @@ function create_crossfilter(data_rows) {
     // whenever the brush moves and other events like that
     function renderAll() {
         chart_DOM_elements.each(render);
-        resultsList(x_filter_dimension[XFILTER_PARAMS.datasetview_chart_index]);
+	//        resultsList(x_filter_dimension[XFILTER_PARAMS.datasetview_chart_index]);
+        resultsTable(x_filter_dimension[XFILTER_PARAMS.datasetview_chart_index]);
         d3.select('#active').text(formatWholeNumber(xfilter_all.value()));
 
         redraw_datasetview();


### PR DESCRIPTION
Replaced the results list with output as a basic (not pretty) HTML table. The row-restricted version turns out to be just as responsive as the original list-based version.

Further work will involve making the table pretty, and also trying full-record implementations using DataTables (which may be expensive but that is unclear for now.) Attempting to display all selected entries now (instead of cap-restricted) is horribly expensive.