### PR TITLE
Full Download List Functionality

### DIFF
--- a/webworm/static/webworm/crossfilter_helpers.js
+++ b/webworm/static/webworm/crossfilter_helpers.js
@@ -4,12 +4,33 @@ var pretty_month_names = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
 			   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ];
 
 function downloadResults() {
-    // *CWL* - Michael, how do we go about getting ALL the selected elements and not just
-    //    the ones on display?
     var returnText = "";
+    let zenodoFilenames = [
+		     '.hdf5',
+		     '.wcon.zip',
+		     '_features.hdf5',
+		     '_skeletons.hdf5',
+		     '_subsample.avi'
+		     ];
+    /*
     $('.results_list_row').each(function (index,element) {
 	    returnText = returnText + index.toString() + "\n";
 	});
+    */
+    // Get grouping by URL
+    let allCFValues = globalCF.dimension(d => d.url).top(Infinity);
+    for (var idx=0; idx<allCFValues.length; idx++) {
+	if (allCFValues[idx].url != "None") {
+	    let urlPrefix = allCFValues[idx].url + "/files/" + allCFValues[idx].fullname;
+	    for (var fIdx=0; fIdx<zenodoFilenames.length; fIdx++) {
+		returnText = returnText + urlPrefix + zenodoFilenames[fIdx] + "\n";
+	    }
+	}
+    }
+    if (returnText == "") {
+	returnText = "Download Warning: No records found!\n";
+    }
+
     var element = document.createElement('a');
     element.setAttribute('href', 'data:text/plain;charset=utf-8,'+encodeURIComponent(returnText));
     element.setAttribute('download', 'results.txt');

--- a/webworm/static/webworm/crossfilter_helpers.js
+++ b/webworm/static/webworm/crossfilter_helpers.js
@@ -3,7 +3,12 @@
 var pretty_month_names = [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
 			   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ];
 
-function downloadResults() {
+// *CWL* - This is the basic form of getting results from Zenodo. A more
+//   advanced form may take the list and perform post-processing like 
+//   allowing the user to choose the element(s) (e.g. Video data only)
+//   to actually be downloaded. In the latter case, we'd want to separate
+//   the common feature of extracting the specific URLs as its own function.
+function downloadResultsList() {
     var returnText = "";
     let zenodoFilenames = [
 		     '.hdf5',

--- a/webworm/static/webworm/crossfilter_helpers.js
+++ b/webworm/static/webworm/crossfilter_helpers.js
@@ -156,12 +156,22 @@ function initializeParamObject() {
 					      "display_name": "Strain" };
     returnObject['data_fields']['allele'] = { "data_type": "string",
 					      "display_name": "Allele" };
+    returnObject['data_fields']['datasize'] = { "data_type": "numeric",
+						"display_name": "Data Size" };
+    returnObject['data_fields']['url'] = { "data_type": "string",
+					   "display_name": "Zenodo Url" };
+    returnObject['data_fields']['fullname'] = { "data_type": "string",
+						"display_name": "Full Experiment Name" };
     returnObject['charts'] = [ "iso_date", "hour" ];
     returnObject['results_display'] = [ 
 				       "pretty_date",
 				       "pretty_time", 
 				       "strain",  
-				       "allele"
+				       "allele",
+    // The next 3 fields are temporary ... for testing only except maybe for datasize, url.
+				       "datasize",
+				       "url",
+				       //				       "fullname",
 					];
     returnObject['max_results'] = 20;
     return returnObject;

--- a/webworm/static/webworm/crossfilter_main.js
+++ b/webworm/static/webworm/crossfilter_main.js
@@ -4,6 +4,10 @@
 //
 "use strict";
 
+// Exposing the crossfilter element so buttons like Download can gain
+//   access to the data elements.
+var globalCF;
+
 if (hasCFData) {
     XFILTER_PARAMS = createXfilterParams(XFILTER_PARAMS, crossfilterData);
     generateXfilterDerivedColumns(crossfilterData);
@@ -77,9 +81,13 @@ function create_crossfilter(data_rows) {
 
     // Create the crossfilter for the relevant dimensions and groups.
     const data_xfilter = crossfilter(data_rows);
+    globalCF = data_xfilter;
     // So we can display the total count of rows selected:
     const xfilter_all = data_xfilter.groupAll();  
     // Get the sum of data sizes
+    //  *CWL* Note - apparently I cannot re-use xfilter_all here ... reduce()
+    //     appears to apply some side-effect to the variable's contents and
+    //     causes it to return NaNs if I tried.
     const xfilter_datasizeSum = 
 	data_xfilter.groupAll().reduce(reduceAdd, reduceRemove, reduceInitial);
 

--- a/webworm/static/webworm/crossfilter_main.js
+++ b/webworm/static/webworm/crossfilter_main.js
@@ -58,10 +58,30 @@ function create_crossfilter(data_rows) {
     // Array that holds the currently selected "in-filter" selected records
     var rows_selected = [];
 
+    // Defining accumulators for datasize
+    var reduceAdd = function(p, v) {
+	p.datasize += v.datasize;
+	return p;
+    }
+
+    var reduceRemove = function(p, v) {
+	p.datasize -= v.datasize;
+	return p;
+    }
+
+    var reduceInitial = function() {
+	return {
+	    datasize : 0
+	}
+    }
+
     // Create the crossfilter for the relevant dimensions and groups.
     const data_xfilter = crossfilter(data_rows);
     // So we can display the total count of rows selected:
     const xfilter_all = data_xfilter.groupAll();  
+    // Get the sum of data sizes
+    const xfilter_datasizeSum = 
+	data_xfilter.groupAll().reduce(reduceAdd, reduceRemove, reduceInitial);
 
     let x_filter_dimension = [];
     let x_filter_dimension_grouped = [];
@@ -103,6 +123,23 @@ function create_crossfilter(data_rows) {
         d3.select(this).call(method);
     }
 
+    function prettySize(valueInMb) {
+	// within reason
+	let scaleText = [ 'Megabytes', 'Gigabytes', 'Terabytes', 'Petabytes', 'Exabytes' ];
+	let scaleIndex = 0;
+	let val = valueInMb;
+	while (val >= 1000) {
+	    scaleIndex += 1;
+	    val /= 1000.0;
+	}
+	if (scaleIndex >= scaleText.length) {
+	    // Punt on prettying the text, something has to be horribly wrong to exceed Exabytes
+	    return valueInMb + " Mb";
+	} else {
+	    return val.toPrecision(4) + " " + scaleText[scaleIndex];
+	}
+    }
+
     // Re-rendering function, which we will later set to be trigged
     // whenever the brush moves and other events like that
     function renderAll() {
@@ -110,7 +147,7 @@ function create_crossfilter(data_rows) {
 	//        resultsList(x_filter_dimension[XFILTER_PARAMS.datasetview_chart_index]);
         resultsTable(x_filter_dimension[XFILTER_PARAMS.datasetview_chart_index]);
         d3.select('#active').text(formatWholeNumber(xfilter_all.value()));
-
+	d3.select('#datasize').text(prettySize(xfilter_datasizeSum.value().datasize));
         redraw_datasetview();
     }
 

--- a/webworm/templates/webworm/crossfilter-template.html
+++ b/webworm/templates/webworm/crossfilter-template.html
@@ -3,7 +3,7 @@
     <h1 id="crossfilter_report_title"></h1>
   </div>
   <div>
-    <button id="downloadExpr" onclick="downloadResults()" type="button" class="btn btn-danger" disabled="true">Download Experiments</button>
+    <button id="downloadExpr" onclick="downloadResultsList()" type="button" class="btn btn-danger" disabled="true">Download Experiments List</button>
     <a href="javascript:resetAll()" class="reset" style="margin-left: -10px; margin-bottom: 20px">Reset all</a>
     <hr>
   </div>

--- a/webworm/templates/webworm/crossfilter-template.html
+++ b/webworm/templates/webworm/crossfilter-template.html
@@ -17,7 +17,8 @@
   </div>
   
   <aside id='totals'>
-    <span id='active'>-</span> of <span id='total'>-</span> experiments selected.
+    <p><span id='active'>-</span> of <span id='total'>-</span> experiments selected.</p>
+    <p>Total data size selected - <span id='datasize'>0 Mb</span></p>
   </aside>
   
   <div id='lists'>


### PR DESCRIPTION
Kind of the wrong branch to add this functionality to, but I failed to catch this before I got started so ...

Anyway this PR implements the full functionality for Download Experiments URLs List to work. The Django server will correctly send the following additional information to the javascript client - video data size (so the user has some idea of approximately how much data he or she is going to have to deal with,) any Zenodo URLs associated with the experiment record (may be "None",) the full name of the experiment (needed to reconstruct the file names of each of the Zenodo files uploaded as part of an experiment's data set.)

The Download button will now go through each filtered record in Crossfilter, construct the required filename URLs (currently 5 of them) if the Zenodo URL is not "None" one per line, and offer it to the user as a text file for further manual processing.

The code sets us up for further refinement and improvement where we can implement more advanced post-processing functionality built into the tool itself. For example it should be fairly trivial to allow the user to indicate he or she wants a zipped package containing only the HDF5 videos in the future.