### PR TITLE
WCON Viewer pane bug fix

### DIFF
--- a/webworm/static/webworm/wormviz_parameters.js
+++ b/webworm/static/webworm/wormviz_parameters.js
@@ -1,5 +1,5 @@
 var WORMVIZ_PARAMS = {
-    "initial_WCON_data_file": "example.wcon",
+    "initial_WCON_data_file": wconFilePath,
     "schema_url": "https://raw.githubusercontent.com/openworm/tracker-commons/master/wcon_schema.json",
     
     "display_despite_schema_errors": true,

--- a/webworm/templates/webworm/index.html
+++ b/webworm/templates/webworm/index.html
@@ -6,7 +6,7 @@
   <ul class="nav nav-tabs" id="tabsUL">
     <li class="active"><a data-toggle="tab" href="#searchPane">Filter Tools</a></li>
     <li><a data-toggle="tab" href="#crossfilterPane">Crossfilter Results</a></li>
-    <li><a data-toggle="tab" href="#wconViewerPane">WCON Viewer</a></li>
+    <li><a data-toggle="tab" href="#wconViewPane">WCON Viewer</a></li>
   </ul>
 
   <div class="tab-content">
@@ -19,14 +19,13 @@
     <div class="tab-pane fade" id="crossfilterPane">
       {% include "webworm/crossfilter-template.html" %}
     </div>
-  </div>
 
-<!-- *CWL* FOR MICHAEL - Output of Data that can be sent to client from server for
-     Crossfiltering
-  {% for item in results_list %}
-  <p>{{ item }}</p>
-  {% endfor %}
--->
+    <!-- WCON Viewer Panel -->
+    <div class="tab-pane fade" id="wconViewPane">
+      {% include "webworm/wconViewer-template.html" %}
+    </div>
+
+  </div>
 
 </div>
 


### PR DESCRIPTION
Fixed the bug. It turns out the original code did not properly install the WCON Viewer Pane into the main collection of panes. As a result, the pane elements could not be found by the accompanying Javascript code.