### PR TITLE
Workaround for the problem of the charts overflow

### DIFF
--- a/webworm/static/webworm/crossfilter_bar_chart.js
+++ b/webworm/static/webworm/crossfilter_bar_chart.js
@@ -28,7 +28,7 @@ function barChart(brushMovedEventHandler) {
         const width = x.range()[1];
         const height = y.range()[0];
 
-        brush.extent([[0, 0], [width, height]])
+        brush.extent([[0, 0], [width + margin.left + margin.right, height]])
             // attach an event handler so if the brush moves,
             // the passed function is called, refreshing global elements
             .on("start brush end", brushMovedEventHandler);


### PR DESCRIPTION
A tentative workaround for the problem of the charts with bars running over the limit.

This workaround will allow the brush slider to move past the edge of the chart itself
to include the left and right margins. For some bizarre reason this works, but I will
slowly get to the right solution soon.

This may not look pretty but it offers better functionality.