### PR TITLE
Support for Loading Screen

### DIFF
--- a/webworm/static/webworm/crossfilter_genData.js
+++ b/webworm/static/webworm/crossfilter_genData.js
@@ -43,16 +43,6 @@ $(document).ready(function() {
             } );
     });
 
-
-// *CWL* - This is no longer required given the latest version of the database.
-//   This was used to strip out the ID from the older format in the form of
-//   xxxxx#yyyyyyyyy where yyyyyyyyy is some text string. This code is retained
-//   as reference.
-function stripZenodoId(inId) {
-    let outId = inId.substring(0,inId.indexOf("#"));
-    return outId;
-}
-
 // *CWL* - This is the basic form of getting results from Zenodo. A more
 //   advanced form may take the list and perform post-processing like 
 //   allowing the user to choose the element(s) (e.g. Video data only)
@@ -64,15 +54,6 @@ function stripZenodoId(inId) {
 //   the use of a linux script to aid with the download in a separate phase.
 function downloadResultsList() {
     var returnText = "";
-    // *CWL* - Point of Code Fragility. These values DEPEND on the type values
-    //         delivered from the server. If one changes without the other,
-    //         this code fails.
-    let zenodoFileTypes = { 'Video':'chk_fullvid',
-			    'WCON':'chk_wcon',
-			    'Features':'chk_features',
-			    'Skeleton':'chk_skeleton',
-			    'Sample':'chk_vidsample'
-                          };
     let zenodoUrlPrefix = 'https://sandbox.zenodo.org/records';
     // Get grouping by Zenodo Id
     let allCFValues = globalCF.dimension(d => d.zenodo_id).top(Infinity);
@@ -81,7 +62,7 @@ function downloadResultsList() {
 	let zenodoId = allCFValues[idx].zenodo_id;
 	let fileType = allCFValues[idx].filetype;
 	if (downloadUrl != 'None') {
-	    if ($('#' + zenodoFileTypes[fileType])[0].checked) {
+	    if ($('#chk_' + fileType).is(':checked')) {
 		returnText = returnText + zenodoId + " " + downloadUrl + "\n";
 	    }
 	}
@@ -189,6 +170,7 @@ function getCsvFromResults() {
 	    createDiscreteHiddenInput('#metadataInput');
 	}
     }
+    loading(true);
     $('#metadataForm').submit();
 }
 
@@ -225,60 +207,6 @@ function generateDownloadData() {
     document.body.removeChild(element); 
 }
 
-function getCsvFromResults_______2() {
-    let data = globalCF.dimension(d => d.zenodo_id).top(Infinity);
-    let filteredFeatures = [];
-    xFilterFeaturesTable.rows({selected: true}).every( function(rowIdx, tblLoop, rowLoop) {
-	    filteredFeatures.push(this.data());
-	});
-
-    let zenodoIDs = {};
-    let newdata = [];
-    // Start with fixed headers
-    let header = ['strain','gene','allele','base_name','zenodo_id'];
-    filteredFeatures.forEach( function(feature, index) {
-	    header.push(feature);
-	});
-
-    // Remove rows with the same zenodoId, choose columns that show up in header
-    data.forEach( function(inner, index) {
-	if (inner['zenodo_id'] != 'None') {
-	    if (zenodoIDs[inner['zenodo_id']] == null) {
-		zenodoIDs[inner['zenodo_id']] = 'Y';
-		let newRow = [];
-		header.forEach( function(key, index) {
-			newRow.push(inner[key]);
-		    });
-		newdata.push(newRow);
-	    }
-	} else {
-	    // If there is no zenodo ID, just add the row.
-	    let newRow = [];
-	    header.forEach( function(key, index) {
-		    newRow.push(inner[key]);
-		});
-	    newdata.push(newRow);
-	}
-	});
-
-    // produce CSV from newly constructed array
-    let csvContent = '';
-    let headerCsv = header.join(',');
-    csvContent += headerCsv + "\n";
-    newdata.forEach( function(row, index) {
-	    let csvRow = row.join(',');
-	    csvContent += csvRow + "\n";
-	});
-
-    let element = document.createElement('a');
-    element.setAttribute('href', 'data:text/plain;charset=utf-8,'+encodeURIComponent(csvContent));
-    element.setAttribute('download', 'results.csv');
-    element.style.display = 'none';
-    document.body.appendChild(element);
-    element.click();
-    document.body.removeChild(element); 
-}
-
 function genDataTable(grouping_dimension) {
     // Re-run the results list, by erasing it and creating it again
 
@@ -293,10 +221,6 @@ function genDataTable(grouping_dimension) {
     let tableBody = table.append("tbody");
     let trs = tableBody.selectAll("tr").data(grouping_dimension.top(XFILTER_PARAMS.max_results))
         .enter().append("tr");
-    /*
-    let trs = tableBody.selectAll("tr").data(grouping_dimension.top(Infinity))
-        .enter().append("tr");
-    */
 
     // Loop over all columns we are supposed to display in the results
     for(let len = XFILTER_PARAMS.results_display.length, i=0; i<len; i++) {

--- a/webworm/static/webworm/crossfilter_helpers.js
+++ b/webworm/static/webworm/crossfilter_helpers.js
@@ -31,25 +31,22 @@ var getUrl = function (zenodo_id, zenodo_filename) {
     return zenodo_download_url;
 }
 
-var getFileType = function (zenodo_filename) {
-    // Check for .hdf5 last please.
-    let fileType = 'None';
-    if (zenodo_filename != 'None') {
-	if (zenodo_filename.endsWith('_features.hdf5')) {
-	    fileType = 'Features';
-	} else if (zenodo_filename.endsWith('_skeletons.hdf5')) {
-	    fileType = 'Skeleton';
-	} else if (zenodo_filename.endsWith('.wcon.zip')) {
-	    fileType = 'WCON';
-	} else if (zenodo_filename.endsWith('_subsample.avi')) {
-	    fileType = 'Sample';
-	} else if (zenodo_filename.endsWith('.hdf5')) {
-	    fileType = 'Video';
-	} else {
-	    fileType = 'Error';
+var generateFileTypeCheckboxes = function() {
+    let columnsPerRow = 6;
+    let rowIdx = 0;
+    for (var i=0; i<fileTypes.length; i++) {
+	if (i%columnsPerRow == 0) {
+	    rowIdx += 1;
+	    $('#filetypeCheckboxes').append('<div class="row" id="filetypeChkRow_' +
+					    rowIdx + '"></div>');
 	}
+	$('#filetypeChkRow_' + rowIdx).append('<div class="col-sm-2"> ' +
+					      '<div class="checkbox active"> ' +
+					      '<label><input type="checkbox" id="chk_' +
+					      fileTypes[i] + '" checked="checked" value="">' +
+					      fileTypes[i] + '</label>' +
+					      '</div></div>');
     }
-    return fileType;
 }
 
 var getYoutubeEmbed = function (youtube_id) {
@@ -70,7 +67,7 @@ var augmentCrossfilterData = function (crossfilterData) {
 	    // turn zenodo_id and zenodo_filename into a URL
 	    row['url'] = getUrl(row['zenodo_id'], row['filename']);
 	    // turn zenodo_filename into a file type string
-	    row['filetype'] = getFileType(row['filename']);
+	    //	    row['filetype'] = getFileType(row['filename']);
 	    // turn 'None' filesize values to 0
 	    if (row['filesize'] == 'None') {
 		row['filesize'] = 0;
@@ -194,7 +191,8 @@ function initializeParamObject() {
     // *CWL* This hardcode of 2 display fields depends on the nature of the static fields
     //    and needs to be generalized. Am thinking the server will send
     //    an appropriate number corresponding to the static fields.
-    returnObject['num_display_fields'] = 2;
+    // returnObject['num_display_fields'] = 2;
+    returnObject['num_display_fields'] = 1;
     returnObject['data_fields'] = {};
     returnObject['data_fields']['timestamp'] = { "data_type": "string",
 						 "display_name": "Date / Time",
@@ -246,7 +244,8 @@ function initializeParamObject() {
     					   "display_name": "YouTube ID" };
     returnObject['data_fields']['youtube'] = { "data_type": "string",
     					   "display_name": "YouTube Sample" };
-    returnObject['charts'] = [ "iso_date", "hour" ];
+    //    returnObject['charts'] = [ "iso_date", "hour" ];
+    returnObject['charts'] = [ "iso_date" ];
     returnObject['results_display'] = [ 
 				       "youtube",
 				       "strain",  

--- a/webworm/static/webworm/crossfilter_main.js
+++ b/webworm/static/webworm/crossfilter_main.js
@@ -8,17 +8,39 @@
 //   access to the data elements.
 var globalCF;
 
-if ((downloadData != 'None') && (downloadHeaders != 'None')) {
-    generateDownloadData();
+function loading(isLoading) {
+    if (!isLoading) {
+	document.getElementById("loader").style.display = "none";
+	document.getElementById("master").style.visibility = "visible";
+    } else {
+	window.scrollTo(0,0);
+	document.getElementById("loader").style.display = "block";
+	document.getElementById("master").style.visibility = "hidden";
+    }
 }
+
 if (hasCFData) {
+    generateFileTypeCheckboxes();
     crossfilterData = augmentCrossfilterData(crossfilterData);
+    // At this point, we're ready to let go of the load screen, and allow
+    //   user interaction with the charts.
+    // The reason we do this before the crossfilter charts are processed
+    //   is because of the style settings. The crossfilter charts rely
+    //   on the style settings of the master DOM to work properly.
+    loading(false);
+
     XFILTER_PARAMS = createXfilterParams(XFILTER_PARAMS, crossfilterData);
     generateXfilterDerivedColumns(crossfilterData);
     processCrossfilterData(crossfilterData);
 } else {
     // If no data is available, use the default example from a file
     d3.csv(XFILTER_PARAMS.data_file, crossfilter_callback);
+}
+if ((downloadData != 'None') && (downloadHeaders != 'None')) {
+    generateDownloadData();
+    // At this point, we're ready to let go of the load screen, and allow
+    //   user interaction with the charts.
+    loading(false);
 }
 
 function crossfilter_callback(error, data_rows) {
@@ -218,15 +240,6 @@ function create_crossfilter(data_rows) {
     // We also listen to the chart's brush events to update the display.
     chart_DOM_elements = d3.selectAll('.chart')
         .data(charts)
-//            .each(function(chart) { console.log(chart); });
-
-/*
-                chart
-                    .on("start brush end", function() {
-                        renderAll();
-                    })
-            });
-*/
 
     // Render the total.
     d3.selectAll('#total')
@@ -253,7 +266,6 @@ function create_crossfilter(data_rows) {
 	// *CWL* - I don't think we need this
         // Passing true to updateDaySelection ensures the checkboxes are reset
 	//        updateDaySelection(true);
-
         renderAll();
     };
 
@@ -266,4 +278,5 @@ function create_crossfilter(data_rows) {
         // here...
         renderAll();
     };
+
 }

--- a/webworm/static/webworm/worm_load.css
+++ b/webworm/static/webworm/worm_load.css
@@ -1,0 +1,47 @@
+/* Center the loader */
+/* from https://www.w3schools.com/howto/tryit.asp?filename=tryhow_css_loader5 */
+#loader {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  z-index: 1;
+  width: 150px;
+  height: 150px;
+  margin: -75px 0 0 -75px;
+  border: 16px solid #f3f3f3;
+  border-radius: 50%;
+  border-top: 16px solid #3498db;
+  width: 120px;
+  height: 120px;
+  -webkit-animation: spin 2s linear infinite;
+  animation: spin 2s linear infinite;
+}
+
+@-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* Add animation to "page content" */
+.animate-bottom {
+  position: relative;
+  -webkit-animation-name: animatebottom;
+  -webkit-animation-duration: 1s;
+  animation-name: animatebottom;
+  animation-duration: 1s
+}
+
+@-webkit-keyframes animatebottom {
+  from { bottom:-100px; opacity:0 } 
+  to { bottom:0px; opacity:1 }
+}
+
+@keyframes animatebottom { 
+  from{ bottom:-100px; opacity:0 } 
+  to{ bottom:0; opacity:1 }
+}

--- a/webworm/templates/webworm/crossfilter-genData-template.html
+++ b/webworm/templates/webworm/crossfilter-genData-template.html
@@ -51,32 +51,7 @@
 	<button id="downloadExpr" onclick="downloadResultsList()" type="button" class="btn btn-danger" disabled="true">Get Experiments Data + Download Script (Linux)</button>
       </div>
     </div>
-    <div class="row">
-      <div class="col-sm-2">
-	<div class="checkbox active">
-	  <label><input type="checkbox" id="chk_fullvid" checked="checked" value="">Full Video Data</label>
-	</div>
-      </div>
-      <div class="col-sm-2">
-	<div class="checkbox active">
-	  <label><input type="checkbox" id="chk_features" checked="checked" value="">Features Data</label>
-	</div>
-      </div>
-      <div class="col-sm-2">
-	<div class="checkbox active">
-	  <label><input type="checkbox" id="chk_skeleton" checked="checked" value="">Skeleton Data</label>
-	</div>
-      </div>
-      <div class="col-sm-2">
-	<div class="checkbox active">
-	  <label><input type="checkbox" id="chk_vidsample" checked="checked" value="">Video Sample</label>
-	</div>
-      </div>
-      <div class="col-sm-2">
-	<div class="checkbox active">
-	  <label><input type="checkbox" id="chk_wcon" checked="checked" value="">WCON Movement Data</label>
-	</div>
-      </div>
+    <div id="filetypeCheckboxes">
     </div>
   </div>
   <hr>

--- a/webworm/templates/webworm/header.html
+++ b/webworm/templates/webworm/header.html
@@ -25,6 +25,8 @@
     <link rel="stylesheet" href="{% static 'webworm/worm_filter.css' %}" />
     <!-- WCON Viewer support -->
     <link rel="stylesheet" href="{% static 'webworm/WCON_viewer.css' %}" />
+    <!-- Loading Screen support -->
+    <link rel="stylesheet" href="{% static 'webworm/worm_load.css' %}" />
 
     <!-- Scripts -->
     <!-- jQuery and Bootstrap and Babel-->

--- a/webworm/templates/webworm/index.html
+++ b/webworm/templates/webworm/index.html
@@ -1,7 +1,9 @@
 {% extends "webworm/header.html" %}
 
 {% block content %}
-<div class="container" id="master">
+<div id="loader"></div>
+
+<div style="visibility:hidden;" class="container animatebottom" id="master">
 
   <ul class="nav nav-tabs" id="tabsUL">
     <li class="active"><a title="Select Features to Crossfilter on. Add restrictions to Database field values. Optional." 
@@ -36,12 +38,15 @@
 
 <script type="text/javascript"> 
   var hasCFData = false;
+  // Temporary hiding of WCON Viewer feature
+  $('#tabsUL a:last').hide();
   if ({{ results_count }} > 0) {
     $('#tabsUL a[href="#crossfilterPane"]').trigger('click');
     $('#downloadExpr').prop('disabled', false);
     $('#generateCsv').prop('disabled', false);
     hasCFData = true;
   }
+  var fileTypes = {{ file_types|safe }};
   var prevAdvancedFilterState = {{ prev_advanced_filter_state|safe }};
   var dataFilePath = "{% static 'webworm/worm_mock_data.csv' %}";
   var wconFilePath = "{% static 'webworm/example.wcon' %}";


### PR DESCRIPTION
Main items
- bug fixes for file downloads. Synced client's file type checkboxes to always match what is defined in the file_types table of the database.
- temporarily disabled WCON Viewer tab.
- Client will now display a loading screen for expensive operations where appropriate.
- removed ability to crossfilter by the hour.