### PR TITLE
Autocomplete applied to Strain Descriptions

### DIFF
--- a/webworm/static/webworm/main-search-bar.js
+++ b/webworm/static/webworm/main-search-bar.js
@@ -4,6 +4,7 @@ $.widget( "custom.catcomplete", $.ui.autocomplete, {
 	    this.widget().menu( "option", "items", "> :not(.ui-autocomplete-category)" );
 	},
 	_renderMenu: function( ul, items ) {
+	    var t0 = performance.now();
 	    var that = this,
 		currentCategory = "";
 	    $.each( items, function( index, item ) {
@@ -17,20 +18,33 @@ $.widget( "custom.catcomplete", $.ui.autocomplete, {
 			li.attr( "aria-label", item.category + " : " + item.label );
 		    }
 		});
+	    var t1 = performance.now();
+	    console.log('Autocomplete Render: ' + (t1-t0) + ' ms');
 	},
     });
 
 // Format - { label: "annhhx10", category: "Products" },
 var databaseFieldData = [];
 
+// Turn strain description table into a dictionary
+var strainDictionary = {};
+for (var idx=0; idx<strainDescriptions.length; idx++) {
+    strainDictionary[strainDescriptions[idx][0]] = strainDescriptions[idx][1];
+}
+
 // Construct database field information for autocomplete search bar
 for (var currIdx=0; currIdx<discreteFieldData.length; currIdx++) {
     for (var recordIdx=0; recordIdx<discreteFieldData[currIdx].length; recordIdx++) {
+	let labelValue = discreteFieldData[currIdx][recordIdx][0];
+	let origValue = labelValue;
+	if (discreteFieldNames[currIdx] == "Strains") {
+	    labelValue += " (" + strainDictionary[labelValue] + ")";
+	}
 	databaseFieldData.push({ 
 		"category" : discreteFieldNames[currIdx],
-         	"label" : discreteFieldData[currIdx][recordIdx][0],
+		"label" : labelValue,
 		"value" : discreteFieldMetadata[currIdx] + "= '" + 
-		          discreteFieldData[currIdx][recordIdx][0] + "'",
+		          origValue + "'",
 		    });
     }
 }

--- a/webworm/templates/webworm/index.html
+++ b/webworm/templates/webworm/index.html
@@ -105,6 +105,7 @@
   var discreteFieldData = {{ discrete_field_counts|safe }};
   var discreteFieldMetadata = {{ discrete_field_meta|safe }};
   var discreteFieldNames = {{ discrete_field_names|safe }};
+  var strainDescriptions = {{ strain_descriptions|safe }};
   var downloadData = {% if download_data %}{{ download_data|safe }}{% else %}'None'{% endif %};
   var downloadHeaders = {% if download_header %}{{ download_header|safe }}{% else %}'None'{% endif %};
 </script>

--- a/webworm/views.py
+++ b/webworm/views.py
@@ -131,6 +131,7 @@ def getDiscreteFieldMetadata(experimentsDb, context):
     global discreteFields;
     experiments_count = experimentsDb.count();
     fieldCounts = [];
+    strainDescriptions = Strains.objects.order_by("name").values_list("name", "description").distinct();
     for tag,field in discreteFields.items():
         exec('' + tag + '_list = ' + field[2] + 
              '.objects.order_by("name").values_list("name", flat=True).distinct();');
@@ -140,6 +141,7 @@ def getDiscreteFieldMetadata(experimentsDb, context):
     context['discrete_field_meta'] = [tag for tag,field in discreteFields.items()];
     context['discrete_field_names'] = [field[1] for tag,field in discreteFields.items()];
     context['discrete_field_counts'] = fieldCounts;
+    context['strain_descriptions'] = [list(item) for item in strainDescriptions];
 
 def processSearchField(key, db_filter, getRequest, dbRecords, filterState):
     returnDbRecords = Experiments.objects.none();


### PR DESCRIPTION
Added special display of description for the Strains field. This allows autocomplete searches

to also include text found in the description. The use-case here is that while certain strain
names are re-names of other strains (e.g. AQ3000 is also N2 but with a different lab.)